### PR TITLE
Require word end in passive voice regexp.

### DIFF
--- a/writegood-mode.el
+++ b/writegood-mode.el
@@ -140,7 +140,7 @@
 (defvar writegood-passive-voice-font-lock-keywords-regexp
   (concat "\\b\\(am\\|are\\|were\\|being\\|is\\|been\\|was\\|be\\)\\b\\([[:space:]]\\|\\s<\\|\\s>\\)+\\([[:word:]]+ed\\|"
 	  (regexp-opt writegood-passive-voice-irregulars)
-	  "\\)")
+	  "\\)\\b")
   "Font-lock keywords regexp for passive-voice")
 
 (defvar writegood-passive-voice-font-lock-keywords


### PR DESCRIPTION
Fixes highlighting parts of adjectives that contain irregular passive forms as a prefix, e.g. "is readily available".
