### PR TITLE
Change weasel words runtime, add user word list

### DIFF
--- a/writegood-mode.el
+++ b/writegood-mode.el
@@ -19,6 +19,19 @@
 ;;  writing.
 ;;  http://matt.might.net/articles/shell-scripts-for-passive-voice-weasel-words-duplicates/
 ;;
+;;  You can change the list writegood-weasel-words using the custom
+;;  interface. If you only need add to the default list of weasel
+;;  words, put them to the list writegood-more-weasel-words. They are
+;;  highlighted next time you turn writewood mode on. Use the custom
+;;  interface or add a lisp statement into your configuration file.
+;;  E.g.:
+;;
+;;    (setq writegood-more-weasel-words
+;;          '("for the purpose of" "for the purposes of"))
+;;
+;;  Remember to modify weasel words only when the writegood-mode is off
+;;  or the highlight gets stuck on changed words.
+;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;;; Change Log:
@@ -95,14 +108,12 @@
   "The weasel words to use"
   :group 'writegood
   :type 'list)
-  
-(defvar writegood-weasels-font-lock-keywords-regexp
-  (concat "\\b" (regexp-opt writegood-weasel-words) "\\b")
-  "Matches weasel-words")
 
-(defvar writegood-weasels-font-lock-keywords
-  (list (list writegood-weasels-font-lock-keywords-regexp
-	      0 (quote 'writegood-weasels-face) 'prepend)))
+(defcustom writegood-more-weasel-words
+  nil
+  "Additional weasel words to use"
+  :group 'writegood
+  :type 'list)
 
 ;; Passive Voice
 (defface writegood-passive-voice-face
@@ -179,9 +190,16 @@
   (interactive)
   (message writegood-version))
 
+(defun writegood-weasels-font-lock-keywords ()
+  "Turn weasel word list into list of regexps"
+  (list (list (concat "\\b"
+                      (regexp-opt (append writegood-weasel-words
+                                          writegood-more-weasel-words)) "\\b")
+              0 (quote 'writegood-weasels-face) 'prepend)))
+
 (defun writegood-weasels-turn-on ()
   "Turn on syntax highlighting for weasels"
-  (font-lock-add-keywords nil writegood-weasels-font-lock-keywords))
+  (font-lock-add-keywords nil (writegood-weasels-font-lock-keywords)))
 
 (defun writegood-passive-voice-turn-on ()
   "Turn on warnings for passive voice"
@@ -193,7 +211,7 @@
 
 (defun writegood-weasels-turn-off ()
   "Turn on syntax highlighting for weasels"
-  (font-lock-remove-keywords nil writegood-weasels-font-lock-keywords))
+  (font-lock-remove-keywords nil (writegood-weasels-font-lock-keywords)))
 
 (defun writegood-passive-voice-turn-off ()
   "Turn on warnings for passive voice"


### PR DESCRIPTION
This patch makes it possible to modify the weasel word list and see
them recognized in the text without reloading the package.

I've taken defvars writegood-weasels-font-lock-keywords-regexp and
writegood-weasels-font-lock-keywords that are there only to process
writegood-weasel-words list, and turned
writegood-weasels-font-lock-keywords into a function that processes
writegood-weasel-words and a new list writegood-more-weasel-words. The
list writegood-more-weasel-words is initially empty, so user can
maintain his/her own word collection.

The advantage of this is that if you want to add new weasel words, the
original weasel word list need not to touched and it is easy to add
new words in runtime. The performance hit caused by turning the list of
weasel words into regular expression every time the mode is toggled
seems to be negligible.

With these changes, it is possible to modify the user word list, e.g.

    (setq writegood-more-weasel-words
          '("for the purpose of" "for the purposes of"))

and toggle on writegood-mode, to see them highlighted in the text. The
main weasel word list can be modified similarly.