### PR TITLE
Don't `require' `cl'

### DIFF
--- a/writegood-mode.el
+++ b/writegood-mode.el
@@ -64,9 +64,6 @@
 ;;
 ;;; Code:
 
-(eval-when-compile
-  (require 'cl))
-
 (require 'regexp-opt)
 (require 'faces)
 


### PR DESCRIPTION
`cl` is deprecated and causes a warning when required; don't `require` it, since
it is isn't even used anywhere.